### PR TITLE
refactor: use `git` + install script 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ steps:
 ```
 
 ## Caching
-`setup-trivy` uses `actions/cache` under the hood but requires less configuration settings. This caches the trivy binary so that next time you run, instead of downloading the binary it is loaded from the cache. This is *not* the same cache as other Trivy artifacts such as `trivy-db` and `trivy-java-db`.
+`setup-trivy` uses `actions/cache` under the hood but requires less configuration settings. 
+This caches the trivy binary so that next time you run, instead of downloading the binary it is loaded from the cache. This is *not* the same cache as other Trivy artifacts such as `trivy-db` and `trivy-java-db`.
+
 The cache input is optional, and caching is turned off by default.
 
-
+**Caching is not supported for empty and `latest` versions!**
 
 ### Enable caching
-If you want to enable caching, set the `cache` input to `true` and specify the `version`.
+If you want to enable caching for Linux and MacOS runners, set the `cache` input to `true` and specify the `version`.
 
 ```yaml
 steps:
@@ -38,4 +40,19 @@ steps:
       cache: true
 ```
 
-**Caching is not supported for empty and `latest` versions!**
+### Custom path to Trivy binary
+`action/cache` doesn't support absolute `path` (see [here](https://github.com/actions/cache/issues/1455) for more details).
+
+To enable caching for Windows runner or if you need to change the Trivy installation directory for other reasons - use `path` input.
+
+**`setup-trivy` adds `trivy-bin` directory to avoid caching unnecessary files** 
+
+```yaml
+steps:
+  - name: Install Trivy
+    uses: aquasecurity/setup-trivy@v0.1.0
+    with:
+      version: v0.56.1
+      cache: true
+      path: "./bins"
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ steps:
 ```
 
 ### Custom path to Trivy binary
-`action/cache` doesn't support absolute `path` (see [here](https://github.com/actions/cache/issues/1455) for more details).
+`action/cache` doesn't support absolute `path` for Windows runners (see [here](https://github.com/actions/cache/issues/1455) for more details).
 
 To enable caching for Windows runner or if you need to change the Trivy installation directory for other reasons - use `path` input.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Set up your GitHub Actions workflow with a specific version of [Trivy](https://g
 # ...
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.1.0
+    uses: aquasecurity/setup-trivy@v0.2.0
 ```
 
 ## Install a specific Trivy version
@@ -15,7 +15,7 @@ steps:
 # ...
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.1.0
+    uses: aquasecurity/setup-trivy@v0.2.0
     with:
       version: v0.56.1
 ```
@@ -34,7 +34,7 @@ If you want to enable caching for Linux and MacOS runners, set the `cache` input
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.1.0
+    uses: aquasecurity/setup-trivy@v0.2.0
     with:
       version: v0.56.1
       cache: true
@@ -50,7 +50,7 @@ To enable caching for Windows runner or if you need to change the Trivy installa
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.1.0
+    uses: aquasecurity/setup-trivy@v0.2.0
     with:
       version: v0.56.1
       cache: true

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,10 @@ inputs:
     description: 'Trivy version to install'
     required: false
     default: 'latest'
+  path:
+    description: 'Path in runner to install Trivy. Trivy will be installed in "<path>/trivy-bin" dir ("$HOME/.local/bin/trivy-bin" by default)'
+    required: false
+    default: '$HOME/.local/bin'
   cache:
     description: 'Used to specify whether caching is needed. Set to false, if you would like to disable caching.'
     required: false
@@ -15,52 +19,46 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # All objects must be lowercase:
-    # https://github.com/jaxxstorm/action-install-gh-release/issues/71#issuecomment-1780893687
-    - name: Set platform name
-      id: set-platform
+    - name: Binary dir
+      id: binary-dir
       shell: bash
-      run: |
-        lowercase_repo=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
-        echo "PLATFORM=${lowercase_repo}" >> $GITHUB_OUTPUT
+      run: echo "dir=${{ inputs.path }}/trivy-bin" >> $GITHUB_OUTPUT
 
-    # All objects must be lowercase:
-    # https://github.com/jaxxstorm/action-install-gh-release/issues/71#issuecomment-1780893687
-    - name: Set arch name
-      id: set-arch
+    ## Don't cache `latest` version
+    - name: Check the version for caching
+      if: ${{ inputs.cache == 'true' && inputs.version == 'latest' }}
       shell: bash
       run: |
-        if [ "${{ runner.arch }}" == "X86" ]; then
-          echo "ARCH=32bit" >> $GITHUB_OUTPUT
-        elif [ "${{ runner.arch }}" == "X64" ]; then
-          echo "ARCH=64bit" >> $GITHUB_OUTPUT
-        elif [ "${{ runner.arch }}" == "ARM" ]; then
-          echo "ARCH=arm" >> $GITHUB_OUTPUT
-        elif [ "${{ runner.arch }}" == "ARM64" ]; then
-          echo "ARCH=arm64" >> $GITHUB_OUTPUT
-        else
-          echo "Unsupported architecture"
-          exit 1
-        fi
+        echo "'setup-trivy' doesn't currently support caching the `latest` version"
+        echo "read https://github.com/aquasecurity/setup-trivy?tab=readme-ov-file#caching for more details"
 
-    # jaxxstorm/action-install-gh-release uses `cache: enable` instead of boolean value
-    - name: Enable cache
-      id: enable-cache
-      shell: bash
-      run: |
-        if [ "${{ inputs.cache }}" == "true" ]; then
-          if [ "${{ inputs.version }}" == "latest" ]; then
-            echo "Trivy binaries caching for 'latest' tag is not supported"
-          else
-            echo "CACHE=enable" >> $GITHUB_OUTPUT
-          fi
-        fi
+    - name: Restore Trivy binary from cache
+      if: ${{ inputs.cache == 'true' && inputs.version != 'latest' }}
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.binary-dir.outputs.dir }}
+        key: trivy-binary-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Checkout install script
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
+      with:
+        repository: aquasecurity/trivy
+        sparse-checkout: |
+          contrib/install.sh
+        sparse-checkout-cone-mode: false
+        path: trivy
+        fetch-depth: 1
 
     - name: Install Trivy
-      uses: jaxxstorm/action-install-gh-release@v1.10.0
-      with:
-        repo: aquasecurity/trivy
-        tag: ${{ inputs.version }}
-        platform: ${{ steps.set-platform.outputs.PLATFORM }}
-        arch: ${{ steps.set-arch.outputs.ARCH }}
-        cache: ${{ steps.enable-cache.outputs.CACHE }}
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "installing Trivy binary"
+        bash ./trivy/contrib/install.sh -b ${{ steps.binary-dir.outputs.dir }} ${{ inputs.version }}
+
+    ## Add the Trivy binary, retrieved from cache or installed by a script, to $GITHUB_PATH
+    - name: Add Trivy binary to $GITHUB_PATH
+      shell: bash
+      run: echo ${{ steps.binary-dir.outputs.dir }} >> $GITHUB_PATH


### PR DESCRIPTION
## Description
Some users can't use `jaxxstorm/action-install-gh-release`, because `jaxxstorm/action-install-gh-release` is not verified in GH marketplace.

So we need to use `git` (preinstalled for all runners) to get install script.

Test runs:
- no inputs - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11289413180
- v0.56.1 version - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11289416369
- v0.56.1 version + caching - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11289419450
- restore v0.56.1 from cache - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11289448917
- v0.56.1 version + caching + `.` path - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11289462287
- restore v0.56.1 + `.` path from cache - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11289481972