### PR TITLE
fix: Remove Trivy installation script (#9)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -62,3 +62,11 @@ runs:
     - name: Add Trivy binary to $GITHUB_PATH
       shell: bash
       run: echo ${{ steps.binary-dir.outputs.dir }} >> $GITHUB_PATH
+
+    ## Remove the Trivy Installation Script as this might cause other linters/checks in the calling
+    ## workflow to fail on the unexpected file
+    - name: Remove Trivy Installation Script
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        rm -f ./trivy/contrib/install.sh


### PR DESCRIPTION
As Trivy checks out its installation script into the same directory as the workflow users own code is typically checked out into this can cause other linters/checks that a workflow is using to fail due to the unexpected install script being present.  This commit modifies the action to ensure that the installation script is removed after the action has installed trivy.

This resolves #9 