### PR TITLE
feat: add `token` input and pin `github-server-url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ steps:
   - name: Install Trivy
     uses: aquasecurity/setup-trivy@v0.2.0
     with:
-      version: v0.56.1
+      version: v0.56.2
 ```
 
 ## Caching
@@ -36,7 +36,7 @@ steps:
   - name: Install Trivy
     uses: aquasecurity/setup-trivy@v0.2.0
     with:
-      version: v0.56.1
+      version: v0.56.2
       cache: true
 ```
 
@@ -52,7 +52,7 @@ steps:
   - name: Install Trivy
     uses: aquasecurity/setup-trivy@v0.2.0
     with:
-      version: v0.56.1
+      version: v0.56.2
       cache: true
       path: "./bins"
 ```
@@ -69,7 +69,7 @@ steps:
   - name: Install Trivy
     uses: aquasecurity/setup-trivy@v0.2.0
     with:
-      version: v0.56.1
+      version: v0.56.2
       cache: true
       token: ${{ secrets.GITHUB_PAT }}
 ```

--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ steps:
       cache: true
       path: "./bins"
 ```
+
+## Install Trivy with non-default token
+There are cases when `github.token` (default value for `actions/checkout`) contains an invalid token for `http://github.com`.
+One of example for this when using GitHub Enterprise Server (GHES).
+See more info in https://github.com/aquasecurity/setup-trivy/issues/10
+
+To properly install Trivy, you need to populate `token` from a secret or another step (e.g. from https://github.com/actions/create-github-app-token)
+
+```yaml
+steps:
+  - name: Install Trivy
+    uses: aquasecurity/setup-trivy@v0.2.0
+    with:
+      version: v0.56.1
+      cache: true
+      token: ${{ secrets.GITHUB_PAT }}
+```

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,15 @@ inputs:
     description: 'Used to specify whether caching is needed. Set to false, if you would like to disable caching.'
     required: false
     default: 'false'
+  token:
+    description: >
+      Access token used to check out the Trivy repository.
+      The token is required when using GitHub Enterprise Server (GHES).
+      https://github.com/actions/create-github-app-token can be used to obtain such a token.
+      The token should be limited to read access only for public repositories.
+      See more details in https://github.com/aquasecurity/setup-trivy/issues/10
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -50,6 +59,11 @@ runs:
         sparse-checkout-cone-mode: false
         path: trivy
         fetch-depth: 1
+        ## We have to explicitly set GitHub server to avoid it being overwritten for GHES
+        ## cf. https://github.com/aquasecurity/setup-trivy/issues/10
+        github-server-url: 'https://github.com'
+        token: ${{ inputs.token }}
+
 
     - name: Install Trivy
       if: steps.cache.outputs.cache-hit != 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,9 @@ inputs:
       The token should be limited to read access only for public repositories.
       See more details in https://github.com/aquasecurity/setup-trivy/issues/10
     required: false
-    default: ''
+    ## ${{ github.token }} is default value for actions/checkout
+    ## cf. https://github.com/actions/checkout/blob/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871/action.yml#L24
+    default: ${{ github.token }}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## Description
GHES overwrites `github.token`. Also default github server for GHES is not `http://github.com`.

This PR:
- pin `http://github.com` as `github-server-url` for `actions/checkout`. Required so that `actions/checkout` correctly finds Trivy repository.
- add `token` input. Default value is `github.token` ([as in actions/checkout](https://github.com/actions/checkout/blob/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871/action.yml#L24)). `token` is required so that users can overwrite invalid (for `http://github.com` server) GHES token. Despite the fact that Trivy is public repository, `checkout` gives an error when the token is invalid.


Test runs:
- token input doesn't exist - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11492659578
- invalid token - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11492667423
- PAT with `public_repo` only - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/11492666014

Related issues:
- Close #10