### PR TITLE
feat: permit override for github-server-url via input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,12 +27,11 @@ inputs:
     ## cf. https://github.com/actions/checkout/blob/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871/action.yml#L24
     default: ${{ github.token }}
   github-server-url:
-    description: >
-      The base URL for the GitHub instance to clone aquasecurity/trivy from.
-      Defaults to public https://github.com, but can be optionally set to ${{ github.server_url }} on GHES.
+    description: The base URL for the GitHub instance to clone aquasecurity/trivy from. Defaults to public https://github.com
     required: false
     ## Note: we explicitly set the default to public rather than the current server api (in case of private GHES)
-    ## cf. https://github.com/aquasecurity/setup-trivy/issues/10
+    ## but it can optionally be set to '${{ github.server_url }}' on GHES if the repository has been mirrored (e.g., via actions/actions-sync).
+    ## Ref. https://github.com/aquasecurity/setup-trivy/issues/10 and https://github.com/aquasecurity/setup-trivy/pull/16
     default: 'https://github.com'
 
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,14 @@ inputs:
     ## ${{ github.token }} is default value for actions/checkout
     ## cf. https://github.com/actions/checkout/blob/eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871/action.yml#L24
     default: ${{ github.token }}
+  github-server-url:
+    description: >
+      The base URL for the GitHub instance to clone aquasecurity/trivy from.
+      Defaults to public https://github.com, but can be optionally set to ${{ github.server_url }} on GHES.
+    required: false
+    ## Note: we explicitly set the default to public rather than the current server api (in case of private GHES)
+    ## cf. https://github.com/aquasecurity/setup-trivy/issues/10
+    default: 'https://github.com'
 
 runs:
   using: 'composite'
@@ -60,11 +68,8 @@ runs:
           contrib
         path: trivy
         fetch-depth: 1
-        ## We have to explicitly set GitHub server to avoid it being overwritten for GHES
-        ## cf. https://github.com/aquasecurity/setup-trivy/issues/10
-        github-server-url: 'https://github.com'
+        github-server-url: ${{ inputs.github-server-url }}
         token: ${{ inputs.token }}
-
 
       ## Install Trivy using install script,
       ## Copy the `contrib` directory to the directory with the binary


### PR DESCRIPTION
A decision was made under
https://github.com/aquasecurity/setup-trivy/issues/10 to make setup-trivy work out of the box for GHES users who had _not_ mirrored aquasecurity/trivy to their GHES instance and who were using GitHub Connect for fetching actions from github.com

However, a number of GHES deployments are airgapped and have taken the opposite approach, do not use GitHub Connect and instead use the actions-sync process to mirror allowed actions into the GHES instance. https://github.com/actions/actions-sync

For those, it is helpful to allow the github-server-url to be overridden as an input to setup-trivy so that the actions/checkout does use the GHES instance as the source