### PR TITLE
docs: bump setup-trivy version from v0.2.2 to v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Set up your GitHub Actions workflow with a specific version of [Trivy](https://g
 # ...
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.2
+    uses: aquasecurity/setup-trivy@v0.2.3
 ```
 
 ## Install a specific Trivy version
@@ -15,9 +15,9 @@ steps:
 # ...
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.2
+    uses: aquasecurity/setup-trivy@v0.2.3
     with:
-      version: v0.56.2
+      version: v0.61.0
 ```
 
 ## Caching
@@ -34,9 +34,9 @@ If you want to enable caching for Linux and MacOS runners, set the `cache` input
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.2
+    uses: aquasecurity/setup-trivy@v0.2.3
     with:
-      version: v0.56.2
+      version: v0.61.0
       cache: true
 ```
 
@@ -50,9 +50,9 @@ To enable caching for Windows runner or if you need to change the Trivy installa
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.2
+    uses: aquasecurity/setup-trivy@v0.2.3
     with:
-      version: v0.56.2
+      version: v0.61.0
       cache: true
       path: "./bins"
 ```
@@ -67,9 +67,9 @@ To properly install Trivy, you need to populate `token` from a secret or another
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.2
+    uses: aquasecurity/setup-trivy@v0.2.3
     with:
-      version: v0.56.2
+      version: v0.61.0
       cache: true
       token: ${{ secrets.GITHUB_PAT }}
 ```

--- a/README.md
+++ b/README.md
@@ -73,3 +73,17 @@ steps:
       cache: true
       token: ${{ secrets.GITHUB_PAT }}
 ```
+
+## Install Trivy with non-default github-server-url
+In some cases, GHES deployments are isolated and don't use GitHub Connect.
+It uses the actions-sync process to mirror allowed actions into the GHES instance.
+
+Set `github-server-url` to change the mirror of Trivy repository.
+```yaml
+steps:
+  - name: Install Trivy
+    uses: aquasecurity/setup-trivy@v0.2.3
+    with:
+      version: v0.61.0
+      github-server-url: 'https://example.com'
+```


### PR DESCRIPTION
## Description
Bump `Trivy` and `setup-trivy` version to cut release.
Also add info about `github-server-url` inut.