### PR TITLE
ci: use `restore` and `save` instead of `actions/cache`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -92,7 +92,7 @@ runs:
     ## So we need to save the binary right after installation.
     ## cf. https://github.com/aquasecurity/setup-trivy/issues/18
     - name: Save Trivy binary from cache
-      if: steps.cache.outputs.cache-hit != 'true'
+      if:  ${{ inputs.cache == 'true' && inputs.version != 'latest' && steps.cache.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.binary-dir.outputs.dir }}

--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ runs:
     - name: Restore Trivy binary from cache
       if: ${{ inputs.cache == 'true' && inputs.version != 'latest' }}
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ${{ steps.binary-dir.outputs.dir }}
         key: trivy-binary-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -86,3 +86,14 @@ runs:
     - name: Add Trivy binary to $GITHUB_PATH
       shell: bash
       run: echo ${{ steps.binary-dir.outputs.dir }} >> $GITHUB_PATH
+
+    ## If one of the steps after setup-trivy fails,
+    ## we won't save the binary to the cache because the step after won't be run.
+    ## So we need to save the binary right after installation.
+    ## cf. https://github.com/aquasecurity/setup-trivy/issues/18
+    - name: Save Trivy binary from cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.binary-dir.outputs.dir }}
+        key: trivy-binary-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}


### PR DESCRIPTION
## Description
The `actions/cache` action doesn't save the cache if one of the steps following it fails.
https://github.com/DmitriyLewen/test-trivy-action/actions/runs/14440129566/job/40488244180#step:7:1

`actions/cache` marked input `save-always` as deprecated - https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/action.yml#L29-L36
Recommended to use action `actions/cache/restore` + `actions/cache/save` - https://github.com/actions/cache/tree/main/save#always-save-cache

### test runs:
- save binary into cache - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/14441076285/job/40491151919#step:3:120
- cache already contains binary - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/14441093708/job/40491208006#step:3:28
- don't use cache - https://github.com/DmitriyLewen/test-trivy-action/actions/runs/14441059496/job/40491099581

## Related Issues
- Close #18