### PR TITLE
chore: use the -c flag on install script

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -78,7 +78,7 @@ runs:
       shell: bash
       run: |
         echo "installing Trivy binary"
-        bash ./trivy/contrib/install.sh -b ${{ steps.binary-dir.outputs.dir }} ${{ inputs.version }}
+        bash ./trivy/contrib/install.sh -b ${{ steps.binary-dir.outputs.dir }} -c gh-action ${{ inputs.version }}
         cp -r ./trivy/contrib ${{ steps.binary-dir.outputs.dir }}/contrib
         rm -rf ./trivy
 

--- a/action.yaml
+++ b/action.yaml
@@ -78,7 +78,7 @@ runs:
       shell: bash
       run: |
         echo "installing Trivy binary"
-        bash ./trivy/contrib/install.sh -b ${{ steps.binary-dir.outputs.dir }} -c gh-action ${{ inputs.version }}
+        bash ./trivy/contrib/install.sh -b ${{ steps.binary-dir.outputs.dir }} -c setup-trivy ${{ inputs.version }}
         cp -r ./trivy/contrib ${{ steps.binary-dir.outputs.dir }}/contrib
         rm -rf ./trivy
 


### PR DESCRIPTION
The `-c` flag on the install script allows for specifying the
caller/client. By Default, the install script will report a client to
the metrics of `install-script`, this will override as `gh-action` to
allow for differentiation in the logs.

> [!WARNING]
> Don't merge till the corresponding script change is merged https://github.com/aquasecurity/trivy/pull/9962