### PR TITLE
chore(deps): bump actions version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,14 +53,14 @@ runs:
     - name: Restore Trivy binary from cache
       if: ${{ inputs.cache == 'true' && inputs.version != 'latest' }}
       id: cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       with:
         path: ${{ steps.binary-dir.outputs.dir }}
         key: trivy-binary-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
     - name: Checkout install script
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         repository: aquasecurity/trivy
         sparse-checkout: |


### PR DESCRIPTION
## Description
Bump actions:
- actions/cache from `v4.2.4` to `v5.0.1`
- actions/checkout from `v5.0.0` to `v6.0.1`