### PR TITLE
docs: use commit SHA and update Trivy version to v0.68.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Set up your GitHub Actions workflow with a specific version of [Trivy](https://g
 # ...
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.3
+    uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
 ```
 
 ## Install a specific Trivy version
@@ -15,9 +15,9 @@ steps:
 # ...
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.3
+    uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
     with:
-      version: v0.61.0
+      version: v0.68.2
 ```
 
 ## Caching
@@ -34,9 +34,9 @@ If you want to enable caching for Linux and MacOS runners, set the `cache` input
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.3
+    uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
     with:
-      version: v0.61.0
+      version: v0.68.2
       cache: true
 ```
 
@@ -50,9 +50,9 @@ To enable caching for Windows runner or if you need to change the Trivy installa
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.3
+    uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
     with:
-      version: v0.61.0
+      version: v0.68.2
       cache: true
       path: "./bins"
 ```
@@ -67,9 +67,9 @@ To properly install Trivy, you need to populate `token` from a secret or another
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.3
+    uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
     with:
-      version: v0.61.0
+      version: v0.68.2
       cache: true
       token: ${{ secrets.GITHUB_PAT }}
 ```
@@ -82,8 +82,8 @@ Set `github-server-url` to change the mirror of Trivy repository.
 ```yaml
 steps:
   - name: Install Trivy
-    uses: aquasecurity/setup-trivy@v0.2.3
+    uses: aquasecurity/setup-trivy@e07451d2e059ed86c2870430ea286b3a9e0bf241
     with:
-      version: v0.61.0
+      version: v0.68.2
       github-server-url: 'https://example.com'
 ```


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                      
  Updates README.md documentation to follow GitHub Actions security best practices and use the latest Trivy version.                                                                                                                              
                                                                                                                                                                                                                                                  
## Changes                                                                                                                                                                                                                                      
  - Replace action version tag `v0.2.3` with commit SHA `e07451d2e059ed86c2870430ea286b3a9e0bf241` in all examples                                                                                                                                
  - Update Trivy version from `v0.61.0` to `v0.68.2` in all usage examples                                                                                                                                                                        
                                                                                                                                                                                                                                                  
  ## Motivation                                                                                                                                                                                                                                   
  - **Security**: Using commit SHA instead of version tags aligns with [GitHub Actions security best practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and prevents potential tag manipulation attacks
  - **Up-to-date examples**: Ensures users are testing with the latest stable Trivy release (v0.68.2)                                                                                                                                             
                                                                                                                                                                                                                                                  
  ## Test plan                                                                                                                                                                                                                                    
  - [x] Verify all 6 code examples in README.md are updated consistently                                                                                                                                                                          
  - [x] Confirm commit SHA points to the latest commit in main branch                       