### PR TITLE
fix!: prevent script injection in run blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ steps:
       path: "./bins"
 ```
 
+> [!IMPORTANT]
+> `path` must be a **literal** path. Shell variables (e.g. `$HOME`, `$RUNNER_TEMP`) and `~` are **not** expanded and will fail the action.
+> Use a GitHub expression that is resolved before the step runs instead, for example `path: ${{ runner.temp }}/trivy`, or a relative path like `./bins`.
+
 ## Install Trivy with non-default token
 There are cases when `github.token` (default value for `actions/checkout`) contains an invalid token for `http://github.com`.
 One of example for this when using GitHub Enterprise Server (GHES).

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,7 @@ runs:
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}
-      run: echo "dir=${INPUT_PATH}/trivy-bin" >> $GITHUB_OUTPUT
+      run: echo "dir=${INPUT_PATH}/trivy-bin" >> "$GITHUB_OUTPUT"
 
     ## Don't cache `latest` version
     - name: Check the version for caching
@@ -96,7 +96,7 @@ runs:
       shell: bash
       env:
         BINARY_DIR: ${{ steps.binary-dir.outputs.dir }}
-      run: echo "${BINARY_DIR}" >> $GITHUB_PATH
+      run: echo "${BINARY_DIR}" >> "$GITHUB_PATH"
 
     ## If one of the steps after setup-trivy fails,
     ## we won't save the binary to the cache because the step after won't be run.

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
   path:
     description: 'Path in runner to install Trivy. Trivy will be installed in "<path>/trivy-bin" dir ("$HOME/.local/bin/trivy-bin" by default)'
     required: false
-    default: '$HOME/.local/bin'
+    default: ''
   cache:
     description: 'Used to specify whether caching is needed. Set to false, if you would like to disable caching.'
     required: false
@@ -42,7 +42,7 @@ runs:
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}
-      run: echo "dir=${INPUT_PATH}/trivy-bin" >> "$GITHUB_OUTPUT"
+      run: echo "dir=${INPUT_PATH:-$HOME/.local/bin}/trivy-bin" >> "$GITHUB_OUTPUT"
 
     ## Don't cache `latest` version
     - name: Check the version for caching

--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,9 @@ runs:
     - name: Binary dir
       id: binary-dir
       shell: bash
-      run: echo "dir=${{ inputs.path }}/trivy-bin" >> $GITHUB_OUTPUT
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+      run: echo "dir=${INPUT_PATH}/trivy-bin" >> $GITHUB_OUTPUT
 
     ## Don't cache `latest` version
     - name: Check the version for caching
@@ -80,16 +82,21 @@ runs:
     - name: Install Trivy
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        BINARY_DIR: ${{ steps.binary-dir.outputs.dir }}
+        TRIVY_VERSION: ${{ inputs.version }}
       run: |
         echo "installing Trivy binary"
-        bash ./trivy/contrib/install.sh -b ${{ steps.binary-dir.outputs.dir }} -c setup-trivy ${{ inputs.version }}
-        cp -r ./trivy/contrib ${{ steps.binary-dir.outputs.dir }}/contrib
+        bash ./trivy/contrib/install.sh -b "${BINARY_DIR}" -c setup-trivy "${TRIVY_VERSION}"
+        cp -r ./trivy/contrib "${BINARY_DIR}/contrib"
         rm -rf ./trivy
 
     ## Add the Trivy binary, retrieved from cache or installed by a script, to $GITHUB_PATH
     - name: Add Trivy binary to $GITHUB_PATH
       shell: bash
-      run: echo ${{ steps.binary-dir.outputs.dir }} >> $GITHUB_PATH
+      env:
+        BINARY_DIR: ${{ steps.binary-dir.outputs.dir }}
+      run: echo "${BINARY_DIR}" >> $GITHUB_PATH
 
     ## If one of the steps after setup-trivy fails,
     ## we won't save the binary to the cache because the step after won't be run.

--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,15 @@ runs:
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}
-      run: echo "dir=${INPUT_PATH:-$HOME/.local/bin}/trivy-bin" >> "$GITHUB_OUTPUT"
+      run: |
+        # `path` is passed via env to avoid script injection, which means shell
+        # variables and `~` inside it are NOT expanded. Fail early with a clear
+        # message instead of silently creating a directory literally named `$HOME`.
+        if [[ "${INPUT_PATH}" == *'$'* || "${INPUT_PATH}" == '~'* ]]; then
+          echo "::error::The 'path' input must be a literal path. Shell variables (e.g. \$HOME, \$USER) and '~' are not expanded. Use an absolute or relative path, or leave 'path' empty to use the default (\$HOME/.local/bin)." >&2
+          exit 1
+        fi
+        echo "dir=${INPUT_PATH:-$HOME/.local/bin}/trivy-bin" >> "$GITHUB_OUTPUT"
 
     ## Don't cache `latest` version
     - name: Check the version for caching

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,12 @@ inputs:
     required: false
     default: 'latest'
   path:
-    description: 'Path in runner to install Trivy. Trivy will be installed in "<path>/trivy-bin" dir ("$HOME/.local/bin/trivy-bin" by default)'
+    description: >
+      Path in runner to install Trivy. Trivy will be installed in "<path>/trivy-bin" dir
+      ("$HOME/.local/bin/trivy-bin" by default).
+      Must be a literal path: shell variables (e.g. $HOME, $RUNNER_TEMP) and "~" are NOT
+      expanded. Use a GitHub expression such as ${{ runner.temp }} instead, or a relative
+      path like "./bins".
     required: false
     default: ''
   cache:
@@ -43,13 +48,23 @@ runs:
       env:
         INPUT_PATH: ${{ inputs.path }}
       run: |
-        # `path` is passed via env to avoid script injection, which means shell
-        # variables and `~` inside it are NOT expanded. Fail early with a clear
-        # message instead of silently creating a directory literally named `$HOME`.
-        if [[ "${INPUT_PATH}" == *'$'* || "${INPUT_PATH}" == '~'* ]]; then
-          echo "::error::The 'path' input must be a literal path. Shell variables (e.g. \$HOME, \$USER) and '~' are not expanded. Use an absolute or relative path, or leave 'path' empty to use the default (\$HOME/.local/bin)." >&2
-          exit 1
-        fi
+        # `path` is passed via env to avoid script injection. As a result, shell
+        # variables (e.g. $HOME) and `~` inside it are NOT expanded. We validate it to:
+        #   1. fail early with a clear message instead of silently creating a directory
+        #      literally named `$HOME`;
+        #   2. reject newlines, which could otherwise inject extra lines into the
+        #      `$GITHUB_OUTPUT` file (and thus poison the `dir` output).
+        case "${INPUT_PATH}" in
+          *'$'* | *'~'*)
+            echo "::error::The 'path' input must be a literal path. Shell variables (e.g. \$HOME, \$USER) and '~' are not expanded. Use a GitHub expression like \${{ runner.temp }}, a relative path, or leave 'path' empty to use the default (\$HOME/.local/bin)." >&2
+            exit 1
+            ;;
+          *[$'\n\r']*)
+            echo "::error::The 'path' input must not contain newline characters." >&2
+            exit 1
+            ;;
+        esac
+        # Default path. Keep `$HOME/.local/bin` in sync with the `path` input description above.
         echo "dir=${INPUT_PATH:-$HOME/.local/bin}/trivy-bin" >> "$GITHUB_OUTPUT"
 
     ## Don't cache `latest` version


### PR DESCRIPTION
## Summary

There are script injection vulnerabilities in `action.yaml` where `${{ }}` expressions are used directly inside `run:` blocks. This PR fixes all affected locations by passing values through `env:` mappings instead, and hardens the `path` input handling.

## Problem

When `${{ }}` expressions are interpolated directly into `run:` blocks, the values are embedded into the shell script before execution. If any user-controlled input (e.g. `inputs.version`, `inputs.path`) contains shell metacharacters, arbitrary commands can be executed.

In practice, the risk is low since these inputs are set by workflow authors rather than external attackers. However, this is a widely recommended security best practice and helps keep the action clean against static analysis tools.

## Changes

- **Pass `${{ }}` values via `env:` instead of inlining them into `run:`** — covers `inputs.path`, `inputs.version`, and `steps.binary-dir.outputs.dir`.

  | Step | Before | After |
  |---|---|---|
  | Binary dir | `${{ inputs.path }}` | `env: INPUT_PATH` |
  | Install Trivy | `${{ steps.binary-dir.outputs.dir }}`, `${{ inputs.version }}` | `env: BINARY_DIR`, `TRIVY_VERSION` |
  | Add Trivy binary to `$GITHUB_PATH` | `${{ steps.binary-dir.outputs.dir }}` | `env: BINARY_DIR` |

- **Quote all shell variable references** (`"$GITHUB_OUTPUT"`, `"$GITHUB_PATH"`, `"${BINARY_DIR}"`, …) to prevent word splitting and glob expansion.

- **Validate the `path` input.** Since the value is now passed via `env:`, shell variables and `~` inside it are no longer expanded. The action rejects such values with a clear error instead of silently creating a directory literally named `$HOME`. It also rejects newlines, which could otherwise inject extra lines into `$GITHUB_OUTPUT` and poison the `dir` output.

- **Resolve the default path inside the shell.** The `path` default is changed to empty and the effective default (`$HOME/.local/bin`) is applied via `${INPUT_PATH:-$HOME/.local/bin}`, so `$HOME` expands correctly.

- **Update docs** — the `path` input description and the README now state that `path` must be a literal path.

## ⚠️ Breaking change

Workflows that explicitly set `path` to a value containing a shell variable or `~` (e.g. `path: '$HOME/.local/bin'`, `path: '$RUNNER_TEMP/trivy'`, `path: '~/bin'`) will now **fail** with a clear error.

Previously these worked because `${{ inputs.path }}` was interpolated into the `run:` block and expanded by the shell. Use a GitHub expression instead — e.g. `path: ${{ runner.temp }}/trivy` — or a literal path like `./bins`.

Users who do **not** set `path` are unaffected: Trivy still installs to `$HOME/.local/bin/trivy-bin`. The official `aquasecurity/trivy-action` does not pass `path` and is not affected.

## References

- [Script injections - GitHub Docs](https://docs.github.com/en/actions/concepts/security/script-injections)
