### PR TITLE
fix: remove literal ${{ runner.temp }} that breaks action loading

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Trivy
         uses: ./
         with:
-          version: v0.68.2
+          version: v0.71.0
 
       - name: Verify Trivy is installed
         shell: bash
@@ -53,7 +53,7 @@ jobs:
       - name: Install Trivy with cache
         uses: ./
         with:
-          version: v0.68.2
+          version: v0.71.0
           cache: true
 
       - name: Verify Trivy is installed
@@ -77,7 +77,7 @@ jobs:
       - name: Install Trivy to a custom path
         uses: ./
         with:
-          version: v0.68.2
+          version: v0.71.0
           path: ./bins
 
       - name: Verify Trivy is installed
@@ -107,7 +107,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          version: v0.68.2
+          version: v0.71.0
           path: $HOME/trivy
 
       - name: Install Trivy with a tilde in path
@@ -115,7 +115,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          version: v0.68.2
+          version: v0.71.0
           path: ~/trivy
 
       - name: Assert the action rejected the invalid paths

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,6 +88,14 @@ jobs:
   # are never silently expanded (regression guard for the validation added in
   # https://github.com/aquasecurity/setup-trivy/pull/33). We expect the install
   # step to FAIL and assert that explicitly.
+  #
+  # The error text printed by the action ("must be a literal path") cannot be
+  # captured from a `uses:` step — only `outcome` is exposed, not stdout/stderr.
+  # So a bare `outcome == failure` check would also pass if the action failed for
+  # an unrelated reason (e.g. the #37 load failure), giving a false green. The
+  # positive-control step below closes that gap: it installs with a valid path
+  # and MUST succeed, so the job can only pass when the action actually loads and
+  # then rejects the invalid paths.
   reject-invalid-path:
     name: Reject invalid path (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -101,6 +109,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      # Positive control: a valid path must load and succeed. If the action is
+      # broken (e.g. an invalid expression in action.yaml), this step fails and
+      # so does the job, preventing a false green from the steps below.
+      - name: Install Trivy with a valid path (control)
+        uses: ./
+        with:
+          version: v0.71.0
+          path: ./control-bin
 
       - name: Install Trivy with a shell variable in path
         id: invalid-var
@@ -129,4 +146,4 @@ jobs:
             echo "::error::Expected the action to reject a path with a tilde, but it succeeded."
             exit 1
           fi
-          echo "Action correctly rejected the invalid paths."
+          echo "Action loaded correctly and rejected the invalid paths."

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,132 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Default usage. This job fails to load if action.yaml contains an invalid
+  # ${{ }} expression (e.g. `runner.temp` in an input description), which is the
+  # regression guard for https://github.com/aquasecurity/setup-trivy/issues/37.
+  defaults:
+    name: Install with defaults (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install Trivy
+        uses: ./
+        with:
+          version: v0.68.2
+
+      - name: Verify Trivy is installed
+        shell: bash
+        run: trivy --version
+
+  cache:
+    name: Install with cache (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install Trivy with cache
+        uses: ./
+        with:
+          version: v0.68.2
+          cache: true
+
+      - name: Verify Trivy is installed
+        shell: bash
+        run: trivy --version
+
+  custom-path:
+    name: Install to custom path (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install Trivy to a custom path
+        uses: ./
+        with:
+          version: v0.68.2
+          path: ./bins
+
+      - name: Verify Trivy is installed
+        shell: bash
+        run: trivy --version
+
+  # The action must reject a `path` that contains shell variables or "~" so they
+  # are never silently expanded (regression guard for the validation added in
+  # https://github.com/aquasecurity/setup-trivy/pull/33). We expect the install
+  # step to FAIL and assert that explicitly.
+  reject-invalid-path:
+    name: Reject invalid path (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install Trivy with a shell variable in path
+        id: invalid-var
+        continue-on-error: true
+        uses: ./
+        with:
+          version: v0.68.2
+          path: $HOME/trivy
+
+      - name: Install Trivy with a tilde in path
+        id: invalid-tilde
+        continue-on-error: true
+        uses: ./
+        with:
+          version: v0.68.2
+          path: ~/trivy
+
+      - name: Assert the action rejected the invalid paths
+        shell: bash
+        run: |
+          if [ "${{ steps.invalid-var.outcome }}" != "failure" ]; then
+            echo "::error::Expected the action to reject a path with a shell variable, but it succeeded."
+            exit 1
+          fi
+          if [ "${{ steps.invalid-tilde.outcome }}" != "failure" ]; then
+            echo "::error::Expected the action to reject a path with a tilde, but it succeeded."
+            exit 1
+          fi
+          echo "Action correctly rejected the invalid paths."

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ steps:
 
 > [!IMPORTANT]
 > `path` must be a **literal** path. Shell variables (e.g. `$HOME`, `$RUNNER_TEMP`) and `~` are **not** expanded and will fail the action.
-> Use a GitHub expression that is resolved before the step runs instead, for example `path: ${{ runner.temp }}/trivy`, or a relative path like `./bins`.
+> Use a GitHub expression that is resolved before the step runs instead, or a relative path like `./bins`.
 
 ## Install Trivy with non-default token
 There are cases when `github.token` (default value for `actions/checkout`) contains an invalid token for `http://github.com`.

--- a/action.yaml
+++ b/action.yaml
@@ -12,8 +12,8 @@ inputs:
       Path in runner to install Trivy. Trivy will be installed in "<path>/trivy-bin" dir
       ("$HOME/.local/bin/trivy-bin" by default).
       Must be a literal path: shell variables (e.g. $HOME, $RUNNER_TEMP) and "~" are NOT
-      expanded. Use a GitHub expression such as ${{ runner.temp }} instead, or a relative
-      path like "./bins".
+      expanded. Use a GitHub expression that is resolved before the step runs, or a
+      relative path like "./bins".
     required: false
     default: ''
   cache:
@@ -56,7 +56,7 @@ runs:
         #      `$GITHUB_OUTPUT` file (and thus poison the `dir` output).
         case "${INPUT_PATH}" in
           *'$'* | *'~'*)
-            echo "::error::The 'path' input must be a literal path. Shell variables (e.g. \$HOME, \$USER) and '~' are not expanded. Use a GitHub expression like \${{ runner.temp }}, a relative path, or leave 'path' empty to use the default (\$HOME/.local/bin)." >&2
+            echo "::error::The 'path' input must be a literal path. Shell variables (e.g. \$HOME, \$USER) and '~' are not expanded. Use a GitHub expression that is resolved before the step runs, a relative path, or leave 'path' empty to use the default (\$HOME/.local/bin)." >&2
             exit 1
             ;;
           *[$'\n\r']*)


### PR DESCRIPTION
## Description

`v0.3.0` fails to load for **every** consumer, even when `path` is not set:

> Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp

GitHub evaluates all `${{ }}` expressions found in `action.yaml`, including
inside input descriptions, where the `runner` context is unavailable. The
literal `${{ runner.temp }}` added to the `path` description in #33 therefore
broke loading the action entirely. The release note for `v0.3.0` ("only affects
you if you explicitly set `path`…") is inaccurate — all users are affected.

## Changes

- Remove the literal `${{ runner.temp }}` from the `path` input description and
  from the validation error message in `action.yaml`, and from `README.md`.
- Add a CI workflow (`.github/workflows/test.yaml`) that runs the action on
  ubuntu/windows/macos (defaults, cache, custom path) and asserts that an
  invalid `path` (shell variable or `~`) is rejected. Using the action via
  `uses: ./` reproduces the load-time failure that static linters miss, so this
  guards against the regression. The `reject-invalid-path` job includes a
  positive-control step (install with a valid path that must succeed) so it can
  never pass when the action fails to load.

## Verification

The new workflow was validated on the fork:

- ✅ With the fix — green run: https://github.com/DmitriyLewen/setup-trivy/actions/runs/26881660038
- 🔴 With the bug deliberately reintroduced — every job (including
  `reject-invalid-path`) fails to load the action with the exact #37 error
  (`Unrecognized named-value: 'runner'`):
  https://github.com/DmitriyLewen/setup-trivy/actions/runs/26881678750

Fixes #37
